### PR TITLE
修复：传入协程中的 context 一旦过期，会导致重试拨号出现 operation was canceled 的错误

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -163,7 +163,7 @@ func (p *ConnPool) newConn(ctx context.Context, pooled bool) (*Conn, error) {
 	if err != nil {
 		p.setLastDialError(err)
 		if atomic.AddUint32(&p.dialErrorsNum, 1) == uint32(p.opt.PoolSize) {
-			go p.tryDial(ctx)
+			go p.tryDial()
 		}
 		return nil, err
 	}
@@ -173,13 +173,13 @@ func (p *ConnPool) newConn(ctx context.Context, pooled bool) (*Conn, error) {
 	return cn, nil
 }
 
-func (p *ConnPool) tryDial(ctx context.Context) {
+func (p *ConnPool) tryDial() {
 	for {
 		if p.closed() {
 			return
 		}
 
-		conn, err := p.opt.Dialer(ctx)
+		conn, err := p.opt.Dialer(context.Background())
 		if err != nil {
 			p.setLastDialError(err)
 			time.Sleep(time.Second)


### PR DESCRIPTION
### 问题：

在 DNS 无法正常解析域名时，会在一段时间后出现 operation was canceled 这个错误，并且在 DNS 恢复正常解析后，依然报相同的错误。

### 解析：

方法 tryDial 中是一个死循环，会不停的去重试拨号直到拨号成功，但是每次拨号使用的 ctx 却是相同的，导致他的过期时间是一个固定的时间。

在底层的 net/dial.go 中，会检查 Dialer 的过期时间，并在 timeout、ctx.Deadline、d.Deadline 中选一个最早的时间，作为后面处理 DNS 和后续拨号时的 context deadline。

net/lookup.go 中，lookupIPAddr 这个方法是用来处理 DNS 解析的，他会在 ctx 过期后，对 ctx.Done() 做对应的错误处理，将 context.Canceled 映射为对应 的 operation was canceled 的错误，然后再逐级向上返回。